### PR TITLE
added Array access to parser

### DIFF
--- a/compiler.js
+++ b/compiler.js
@@ -68,15 +68,30 @@ class CallerArgument extends Node {
 }
 
 class ArrayElement extends Node {
-  constructor({name, index}) {
+  constructor({name, index, foreign = false}) {
     super();
     this.name = name;
     this.index = index;
+    this.foreign = foreign; // means the array is not in our stack frame as it was passed to our function (cannot compute from rbp)
   }
 
   toAssembly(symbolTable) {
-    const address = (symbolTable[this.name] + this.index * INT_SIZE) * -1;
-    return `DWORD PTR [rbp - ${address}]`;
+    if (!this.foreign) {
+      const address = (symbolTable[this.name] + this.index * INT_SIZE) * -1;
+      return `DWORD PTR [rbp - ${address}]`;
+    } else {
+      // TODO: refactor me so that ArrayElement doesn't return either a list of instructions or an operand
+      // TODO: refactor me so that this.index isn't either a number or a variable name
+      const baseAddress = symbolTable[this.name] * -1;
+      const indexAddress = symbolTable[this.index] * -1;
+      return {
+        preInstructions: [
+          `mov rcx, DWORD PTR [rbp - ${baseAddress}]`,
+          `mov rdx, DWORD PTR [rbp - ${baseAddress}]`
+        ],
+          resultOperand: 'DWORD PTR [rcx + 4*rdx]'
+        }
+    }
   }
 }
 
@@ -143,10 +158,17 @@ class BinaryExpression extends Node {
     const op1 = this.operand1.toAssembly(symbolTable);
     const op2 = this.operand2.toAssembly(symbolTable);
 
-    const instructions = [
-      `mov eax, ${op1}`,
-      `${operatorToInstruction[this.operator]} eax, ${op2}`
+    let instructions = [
+      `mov eax, ${op1}`
     ];
+
+    // TODO: refactor this preInstruction business
+    if (op2.preInstructions) {
+      instructions = instructions.concat(op2.preInstructions);
+      instructions.push(`${operatorToInstruction[this.operator]} eax, ${op2.resultOperand}`)
+    } else {
+      instructions.push(`${operatorToInstruction[this.operator]} eax, ${op2}`)
+    }
 
     return instructions;
   }
@@ -179,6 +201,12 @@ class Assignment extends Node {
       } else if(this.operand.type === 'immediate') {
         return `mov ${destination}, ${this.operand.toAssembly(symbolTable)}`;
       }
+    } else if (this.operand instanceof ArrayElement) {
+      const arr = this.operand.toAssembly(symbolTable);
+      return [
+        arr.preInstructions,
+        `mov ${destination}, ${arr.resultOperand}`
+      ].flat();
     }
   }
 }
@@ -357,7 +385,7 @@ class ArrayDeclaration extends Node {
     const baseAddress = symbolTable[this.destination];
     let instructions = this.values.map((value, index) => {
        const address = (baseAddress + index * INT_SIZE) * -1;
-       const element = new ArrayElement({name: this.destination, "index": index}).toAssembly(symbolTable);
+       const element = new ArrayElement({name: this.destination, "index": index, foreign: false}).toAssembly(symbolTable);
        return `mov ${element}, ${value}`
     });
     return instructions;

--- a/index.html
+++ b/index.html
@@ -21,18 +21,21 @@
       <div class="editor col-sm">
         <h4>C++ source</h4>
         <textarea class="editor-textbox code-font">
-int sum(int num[5]){
-  int sum=0;
-  for(int i=0;i<5;i=i+1){
-    sum=sum+i;
+int max(int a[5]) {
+  int max = 0;
+
+  for (int i=0; i<5; i++) {
+    if (max < a[i]) {
+      max = a[i];
+    }
   }
-  return sum;
+
+  return max;
 }
 
 int main() {
-  int k[3] = {0,1,2};
-  int result = 0;
-  result = sum(k);
+  int a[3] = {1, 2, 3};
+  int m = max(a);
 }
         </textarea>
         <button class="button-compile btn btn-lg btn-primary" type="">compile to x86</button>

--- a/parser.js
+++ b/parser.js
@@ -91,7 +91,7 @@ function parseOperand(string) {
   }
   let between = splitArray(string);
   if (between.length)// if is array, only supports 1 dimensional arrays
-    return new ArrayElement({name: between[0], value: between[1]});
+    return new ArrayElement({name: between[0], value: between[1], foreign: true});
   else
     return new Operand({type: "variable", value: string});
 }
@@ -173,7 +173,7 @@ class Parser {
     if(assignmentLine[1] === '='){
       if(assignmentLine.length === 3){
         return new Assignment({
-          desination: parseOperand(assignmentLine[0]),
+          destination: parseOperand(assignmentLine[0]),
           operand: parseOperand(assignmentLine[2])
         });
       }
@@ -222,6 +222,7 @@ class Parser {
   }
 
   makeIfStatement(condition, statements){
+    condition = groupArray(condition)
     return new If({
       condition: new BinaryExpression({
         operator: condition[1],

--- a/parser.js
+++ b/parser.js
@@ -56,8 +56,8 @@ function groupArray(assignmentLine) {
     let curr = assignmentLine[i];
     if (curr == ']') {
       stk[stk.length-1] += between + curr;
-      stk[stk.length-1] = stk[stk.length-2] + stk[stk.length-1];
-      stk.shift();
+      stk[stk.length-2] = stk[stk.length-2] + stk[stk.length-1];
+      stk.pop();
       between = '';
     } else if (curr == '[') {
       stk.push(curr);

--- a/parser.js
+++ b/parser.js
@@ -48,11 +48,15 @@ function parseOperand(string) {
   if (isNumber(string)) {
     return new Operand({type: "immediate", value: Number(string)});
   }
-
-  return new Operand({type: "variable", value: string});
+  //if (string.includes('[')) {// if is array
+  //  let between = '';
+  //  
+  //  return new Operand({type: "variable", value: })
+  //} else  
+    return new Operand({type: "variable", value: string});
 }
 
-class Parser{
+class Parser {
   constructor(sourceCode){
     this.declarations = 0;
     this.source = sourceCode;
@@ -104,7 +108,34 @@ class Parser{
     }
   }
 
+  groupArray(assignmentLine) {
+    let stk = [];
+    // treat front of array like a stack
+    // go from the front of the assignment line
+    // if we see [ then push to the array
+    // until we see ] we add elements to the back element of array
+    let between = '';
+    for (let i = 0; i < assignmentLine.length; i++) {
+      let curr = assignmentLine[i];
+      if (curr == ']') {
+        stk[stk.length-1] += between + curr;
+        stk[stk.length-1] = stk[stk.length-2] + stk[stk.length-1];
+        stk.shift();
+        between = '';
+      } else if (curr == '[') {
+        stk.push(curr);
+      } else {
+        if (stk.length && stk[stk.length-1] == '[')
+          between += curr;
+        else
+          stk.push(curr);
+      }
+    } return stk;
+  }
+
   makeAssignment(assignmentLine){
+    assignmentLine = this.groupArray(assignmentLine);
+    console.log(assignmentLine);
     //i = 1 || i = x
     if(assignmentLine[1] === '='){
       if(assignmentLine.length === 3){
@@ -284,6 +315,7 @@ class Parser{
         default:{
           let statement = [];
           for(let i=0; i<source.length; i++){
+            
             if(source[i] != ';')
               statement.push(source[i]);
             else{

--- a/parser.js
+++ b/parser.js
@@ -91,8 +91,8 @@ function parseOperand(string) {
   }
   let between = splitArray(string);
   if (between.length)// if is array, only supports 1 dimensional arrays
-    return new ArrayElement({name: arr[0], value: arr[1]});
-  else  
+    return new ArrayElement({name: between[0], value: between[1]});
+  else
     return new Operand({type: "variable", value: string});
 }
 


### PR DESCRIPTION
implemented array parsing by implementing groupArray and splitArray

Note that if no array exists in the line passed to groupArray the line will return unaltered and if no array exists in splitArray the line will return empty

groupArray() solves the issue of assignment lines or condition lines splitting up components of an array separately like we had before ["arr", "[", "i", "]"]. given a split array like this it groups it into "arr[i]" as a whole

 Now that we can pass the groupedArray into parseOperand we split the array using splitArray() up into the array name and the index between the brackets. this is now usable in compiler.js' ArrayElement({name:, index}) constructor

added groupArray call to conditions in makeIfStatement
added groupArray call to assignmentLine in makeAssignment
added splitArray call to parseOperand
technically i think a groupArray call should be placed for the condition in makeForLoop, but i am hesitant to add it in there